### PR TITLE
Add a security manager to the judge code

### DIFF
--- a/judge.policy
+++ b/judge.policy
@@ -1,0 +1,19 @@
+
+grant codeBase "file:${java.ext.dirs}/*" {
+        permission java.security.AllPermission;
+};
+
+grant {
+        permission java.util.PropertyPermission "java.class.version", "read";
+        permission java.util.PropertyPermission "file.separator", "read";
+        permission java.util.PropertyPermission "path.separator", "read";
+        permission java.util.PropertyPermission "line.separator", "read";
+
+        permission java.lang.RuntimePermission "setIO";
+        permission java.lang.RuntimePermission "accessDeclaredMembers";
+        permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
+        permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+
+        permission java.util.PropertyPermission "dodona.language", "read";
+};
+

--- a/run
+++ b/run
@@ -256,6 +256,13 @@ fi
 dodona close-tab
 
 # Running the tests
-java -Xmx"${memory_limit}k" -cp ".:${worklibs}:${testlibs}:judge.jar:${resources}/properties" -Ddodona.language="${natural_language}" dodona.junit.JUnitJSON
+java -Xmx"${memory_limit}k" \
+     -cp ".:${worklibs}:${testlibs}:judge.jar:${resources}/properties" \
+     -Djava.security.manager -Djava.security.policy=="$judge/judge.policy" \
+     -Ddodona.language="${natural_language}" \
+     dodona.junit.JUnitJSON
+
+# to debug security failure, add:
+#-Djava.security.debug=access,failure \
 
 dodona close-judgement


### PR DESCRIPTION
Disallows all "dangerous" methods. Requires a lot more testing to find
out which permissions the judge still needs to do it's job.