### PR TITLE
Fix the filename of the Interactive example

### DIFF
--- a/examples/interactive/config.json
+++ b/examples/interactive/config.json
@@ -6,7 +6,7 @@
     }
   },
   "evaluation": {
-    "filename": "InteractiveProgram.java",
+    "filename": "Echo.java",
     "handler": "java12"
   }
 }


### PR DESCRIPTION
I am currently experimenting with Github Actions to compile the Judge and run it against all the example exercises automatically; and noticed that this one was failing.