### PR TITLE
Allow System.exit() calls in Interactive tests

### DIFF
--- a/src/dodona/util/Interactive.java
+++ b/src/dodona/util/Interactive.java
@@ -1,5 +1,6 @@
 package dodona.util;
 
+import dodona.junit.ExitException;
 import dodona.junit.MultiMessageWriter;
 import dodona.junit.TestWriter;
 import org.junit.Assert;
@@ -99,8 +100,11 @@ public class Interactive implements TestRule {
         } catch (final IllegalAccessException e) {
             Assert.fail("Method could not be called: public static void main(String[])");
         } catch (final InvocationTargetException e) {
-            // An exception occurred while running the program.
-            throw e.getCause();
+            // An exception occurred while running the program. Ignore this if
+            // it's because of a call to System.exit(), as this might be desired
+            if (!(e.getCause() instanceof ExitException)) {
+                throw e.getCause();
+            }
         } finally {
             // Log the output.
             this.logOutput();


### PR DESCRIPTION
Students often use `System.exit()` in interactive programs as an alternative to simply writing `return` in the `main`-method, because the concept of functions/methods has not been taught yet. This PR allows `System.exit()` to be used in Interactive tests without throwing an AssertionError. 

In the future, this behaviour might be extended to mimic `ExpectedSystemExit`-behaviour.