### PR TITLE
Limit the size of the stack trace

### DIFF
--- a/examples/i18n/tests/stackoverflow.en.result
+++ b/examples/i18n/tests/stackoverflow.en.result
@@ -1,0 +1,58 @@
+{
+  "command": "start-judgement"
+}
+{
+  "command": "start-tab",
+  "hidden": true,
+  "title": "Compiler"
+}
+{
+  "command": "close-tab"
+}
+{
+  "command": "start-tab",
+  "hidden": false,
+  "title": "Test"
+}
+{
+  "command": "start-context",
+  "description": {
+    "description": "Translated Test",
+    "format": "code"
+  }
+}
+{
+  "command": "start-testcase",
+  "description": {
+    "description": "java.lang.StackOverflowError",
+    "format": "code"
+  }
+}
+{
+  "command": "escalate-status",
+  "status": {
+    "enum": "runtime error",
+    "human": "Uitvoeringsfout"
+  }
+}
+{
+  "command": "append-message",
+  "message": {
+    "description": "Caused by java.lang.StackOverflowError\n ...",
+    "format": "code"
+  }
+}
+{
+  "accepted": false,
+  "command": "close-testcase"
+}
+{
+  "accepted": false,
+  "command": "close-context"
+}
+{
+  "command": "close-tab"
+}
+{
+  "command": "close-judgement"
+}

--- a/examples/i18n/tests/stackoverflow.en.submission
+++ b/examples/i18n/tests/stackoverflow.en.submission
@@ -1,0 +1,7 @@
+public class Translated {
+
+    public String getLanguage() {
+        return getLanguage();
+    }
+
+}

--- a/integration-tests
+++ b/integration-tests
@@ -33,6 +33,7 @@ for exercise in examples/*; do
               | diff $judge/${base}.result -
 
         cd "$judge"
+        rm -r "$workdir"
         echo passed
     done
 done

--- a/src/dodona/junit/JSONListener.java
+++ b/src/dodona/junit/JSONListener.java
@@ -29,6 +29,8 @@ import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
 public class JSONListener extends RunListener {
+    private static final int STACKSIZE = 50;
+
     private final ResourceBundle descriptions;
     private final PrintStream writer;
     private final Json json;
@@ -113,13 +115,14 @@ public class JSONListener extends RunListener {
                     message.append("Caused by " + thrown);
                     StackTraceElement[] stacktrace = thrown.getStackTrace();
                     boolean leftDefaultPackage = false;
-                    for(int i = 0; i < stacktrace.length; i++) {
+                    for(int i = 0; i < stacktrace.length && i < STACKSIZE; i++) {
                         // student code in default package
                         boolean inDefaultPackage = stacktrace[i].getClassName().indexOf('.') < 0;
                         if(leftDefaultPackage && !inDefaultPackage) break;
                         if(inDefaultPackage) leftDefaultPackage = true;
                         message.append("\n at " + stacktrace[i].toString());
                     }
+                    if(stacktrace.length >= STACKSIZE) message.append("\n ...");
                     write(new AppendMessage(Message.code(message.toString())));
                     thrown = thrown.getCause();
                 }


### PR DESCRIPTION
This should hinder students breaking the 10MB limit on judge output with
infinite recursion. The stack_limit option to the judge can be used to
increase the size for some exercises.