### PR TITLE
Handle package-private constructor/methods in AssertionStubber

### DIFF
--- a/examples/diffing-testwriter/tests/package.en.result
+++ b/examples/diffing-testwriter/tests/package.en.result
@@ -31,7 +31,7 @@
 {
   "command": "start-testcase",
   "description": {
-    "description": "Missing method: String hello()",
+    "description": "Inaccessible method: String hello(). Method should have a \"public\" modifier.",
     "format": "code"
   }
 }

--- a/examples/stubber/tests/package.result
+++ b/examples/stubber/tests/package.result
@@ -31,7 +31,7 @@
 {
   "command": "start-testcase",
   "description": {
-    "description": "Missing method: boolean isStubbed()",
+    "description": "Inaccessible method: boolean isStubbed(). Method should have a \"public\" modifier.",
     "format": "code"
   }
 }


### PR DESCRIPTION
Tests have been updated.

The `AssertionStubber` first tries to load the constructor and methods using `getConstructor()` and `getMethod`. If this results in a `NoSuchMethodException`, it is loaded using the `getDeclaredConstructor()` and `getDeclaredMethod` functions. If this succeeds, the method exists but with an incorrect visibility. If this does not succeed, the method is really non existent.