### PR TITLE
Implement i18n-able TabTitles

### DIFF
--- a/examples/i18n/evaluation/TranslatedTest.java
+++ b/examples/i18n/evaluation/TranslatedTest.java
@@ -1,9 +1,11 @@
 import dodona.i18n.Language;
+import dodona.i18n.I18nTabTitle;
 import dodona.i18n.I18nTestDescription;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+@I18nTabTitle("tab_title")
 public class TranslatedTest {
 
     @Test

--- a/examples/i18n/evaluation/properties/descriptions.en.properties
+++ b/examples/i18n/evaluation/properties/descriptions.en.properties
@@ -1,1 +1,2 @@
+tab_title=Translated title
 translated_description=Translated Test

--- a/examples/i18n/evaluation/properties/descriptions.nl.properties
+++ b/examples/i18n/evaluation/properties/descriptions.nl.properties
@@ -1,1 +1,2 @@
+tab_title=Vertaalde titel
 translated_description=Vertaalde Test

--- a/examples/i18n/tests/correct.en.result
+++ b/examples/i18n/tests/correct.en.result
@@ -12,7 +12,7 @@
 {
   "command": "start-tab",
   "hidden": false,
-  "title": "Test"
+  "title": "Translated title"
 }
 {
   "command": "start-context",

--- a/examples/i18n/tests/correct.nl.result
+++ b/examples/i18n/tests/correct.nl.result
@@ -12,7 +12,7 @@
 {
   "command": "start-tab",
   "hidden": false,
-  "title": "Test"
+  "title": "Vertaalde titel"
 }
 {
   "command": "start-context",

--- a/examples/i18n/tests/stackoverflow.en.result
+++ b/examples/i18n/tests/stackoverflow.en.result
@@ -12,7 +12,7 @@
 {
   "command": "start-tab",
   "hidden": false,
-  "title": "Test"
+  "title": "Translated title"
 }
 {
   "command": "start-context",

--- a/src/dodona/i18n/I18nTabTitle.java
+++ b/src/dodona/i18n/I18nTabTitle.java
@@ -1,0 +1,23 @@
+package dodona.i18n;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Sets the title of the tab, which is shown on Dodona on top with a badge
+ * displaying the amount of failed test cases. The value should be a key that is
+ * configured in both of the following files:
+ * <p>
+ * evaluation/properties/descriptions.en.properties
+ * evaluation/properties/descriptions.nl.properties
+ * <p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface I18nTabTitle {
+    /**
+     * The resource key of the description to display.
+     *
+     * @return the resource key
+     */
+    String value();
+}

--- a/src/dodona/junit/JSONListener.java
+++ b/src/dodona/junit/JSONListener.java
@@ -10,6 +10,7 @@ import dodona.feedback.StartContext;
 import dodona.feedback.StartTab;
 import dodona.feedback.StartTestcase;
 import dodona.feedback.Status;
+import dodona.i18n.I18nTabTitle;
 import dodona.i18n.I18nTestDescription;
 import dodona.i18n.Language;
 import dodona.json.Json;
@@ -72,8 +73,9 @@ public class JSONListener extends RunListener {
     public void afterExecution() {}
 
     public void beforeTab(Description description) {
-        TabTitle tabAnnotation = description.getAnnotation(TabTitle.class);
-        String title = tabAnnotation == null ? "Test" : tabAnnotation.value();
+        final String title = this.getI18nTabTitle(description)
+            .orElseGet(() -> this.getTabTitle(description)
+                .orElse(TabTitle.DEFAULT));
         write(new StartTab(title));
     }
 
@@ -145,7 +147,22 @@ public class JSONListener extends RunListener {
             .orElseGet(() -> getTestDescription(desc)
                 .orElse(desc.getDisplayName()));
     }
-
+    
+    /**
+     * Parse a @I18nTabTitle annotation.
+     *
+     * @param desc the description
+     * @return the value of the I18nTabTitle annotation if available
+     */
+    private Optional<String> getI18nTabTitle(final Description desc) {
+        return Optional.ofNullable(this.descriptions).flatMap(bundle ->
+            Optional.ofNullable(desc.getAnnotation(I18nTabTitle.class))
+                .map(I18nTabTitle::value)
+                .filter(bundle::containsKey)
+                .map(bundle::getString)
+        );
+    }
+    
     /**
      * Parse a @I18nTestDescription annotation.
      *
@@ -159,6 +176,16 @@ public class JSONListener extends RunListener {
                 .filter(bundle::containsKey)
                 .map(bundle::getString)
         );
+    }
+    
+    /**
+     * Parse a @TabTitle annotation.
+     *
+     * @param desc the description
+     * @return the value of the TabTitle annotation if available
+     */
+    private Optional<String> getTabTitle(final Description desc) {
+        return Optional.ofNullable(desc.getAnnotation(TabTitle.class)).map(TabTitle::value);
     }
 
     /**

--- a/src/dodona/junit/TabTitle.java
+++ b/src/dodona/junit/TabTitle.java
@@ -4,5 +4,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TabTitle {
+    String DEFAULT = "Test";
+    
     String value();
 }


### PR DESCRIPTION
This PR implements translatable TabTitles, in the same way as this is implemented with translatable TestDescriptions.

To accomplish this, an `I18nTabTitle`-annotation was added, with accompanying tests.